### PR TITLE
Upgrade to JDK 11, and ensure latest minor version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM adoptopenjdk/openjdk11
 MAINTAINER Patrick Reinhart <patrick@reini.net>
-RUN apt-get update && apt-get install -y --no-install-recommends ksh mercurial nano && apt-get build-dep -y openjdk-9
+RUN apt-get update && apt-get install -y --no-install-recommends ksh mercurial nano && apt-get build-dep -y openjdk-11
 RUN curl https://adopt-openjdk.ci.cloudbees.com/job/jtreg/lastSuccessfulBuild/artifact/jtreg-4.2.0-tip.tar.gz | tar -xvz -C /opt
 ENV LANG=C JT_HOME=/opt/jtreg PATH="/usr/lib/jvm/java-9-openjdk-amd64/bin:/opt/jtreg/bin:${PATH}" WDIR=/openjdk/reviews
 COPY hgrc /root/.hgrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk9:x86_64-ubuntu-jdk-9.181
+FROM adoptopenjdk/openjdk11
 MAINTAINER Patrick Reinhart <patrick@reini.net>
 RUN apt-get update && apt-get install -y --no-install-recommends ksh mercurial nano && apt-get build-dep -y openjdk-9
 RUN curl https://adopt-openjdk.ci.cloudbees.com/job/jtreg/lastSuccessfulBuild/artifact/jtreg-4.2.0-tip.tar.gz | tar -xvz -C /opt


### PR DESCRIPTION
Users will almost certainly benefit from updating to the latest LTS major version of Java. This upgrade adds cgroup awareness, an essential feature for preventing OOM kills on a container platform; generally improves performance; and is much less likely to break existing code than the migration from JDK 8 to 9 did.

I also noticed this Dockerfile specifies a fixed minor version of Java; it's almost certainly best to always use the latest minor version, since this provides essential security patches and minor-version updates very rarely cause breakages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/reinhapa/openjdk-dev/1)
<!-- Reviewable:end -->
